### PR TITLE
[housekeeping] Update Sample project and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ Add the following permissions to your `AndroidManifest.xml`:
 <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 ```
+> [!NOTE]
+> While picking images using `MediaPicker`, the images may lose GPS EXIF data due to Android privacy restrictions  and the underlying APIs used in `MediaPicker` (Android API 29+). 
+>If you want to access GPS info for these images as well, you need to declare and request the `ACCESS_MEDIA_LOCATION`  runtime permission.
 
 ### iOS
 No special permissions required for reading EXIF data from files accessible to your app.

--- a/README.md
+++ b/README.md
@@ -148,8 +148,11 @@ Add the following permissions to your `AndroidManifest.xml`:
 <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 ```
 > [!NOTE]
-> While picking images using `MediaPicker`, the images may lose GPS EXIF data due to Android privacy restrictions  and the underlying APIs used in `MediaPicker` (Android API 29+). 
->If you want to access GPS info for these images as well, you need to declare and request the `ACCESS_MEDIA_LOCATION`  runtime permission.
+> When using `MediaPicker.PickPhotoAsync()`, the selected image may not include GPS EXIF data due to Android privacy restrictions (API 29+).  
+> To access GPS metadata in this case, you must declare and request the `ACCESS_MEDIA_LOCATION` runtime permission.
+>
+> When using `MediaPicker.CapturePhotoAsync()`, the GPS data may be missing unless your app has location permissions (`ACCESS_FINE_LOCATION` or `ACCESS_COARSE_LOCATION`) and the selected camera app supports embedding location info.  
+> Note that the camera app behavior varies across devices and cannot be controlled by your app.
 
 ### iOS
 No special permissions required for reading EXIF data from files accessible to your app.

--- a/samples/Plugin.Maui.Exif.Sample/Internals/PermissionUtility.cs
+++ b/samples/Plugin.Maui.Exif.Sample/Internals/PermissionUtility.cs
@@ -1,0 +1,44 @@
+﻿using static Microsoft.Maui.ApplicationModel.Permissions;
+
+namespace Plugin.Maui.Exif.Sample;
+
+internal static class PermissionUtility
+{
+    public static async Task<PermissionStatus> RequestLocationPermissionAsync()
+    {
+        var status = await Permissions.CheckStatusAsync<LocationWhenInUse>();
+        if (status != PermissionStatus.Granted)
+        {
+            status = await Permissions.RequestAsync<LocationWhenInUse>();
+        }
+        return status;
+    }
+
+    public static async Task<PermissionStatus> RequestMediaLocationPermissionAsync()
+    {
+        if (OperatingSystem.IsAndroid() && OperatingSystem.IsAndroidVersionAtLeast(29))
+        {
+            var status = await Permissions.CheckStatusAsync<MediaLocation>();
+            if (status != PermissionStatus.Granted)
+            {
+                status = await Permissions.RequestAsync<MediaLocation>();
+            }
+            return status;
+        }
+        else
+        {
+            return PermissionStatus.Granted;
+        }
+    }
+}
+
+public class MediaLocation : BasePlatformPermission
+{
+#if ANDROID
+    public override (string androidPermission, bool isRuntime)[] RequiredPermissions =>
+        new[]
+        {
+            (global::Android.Manifest.Permission.AccessMediaLocation, true)
+        };
+#endif
+}

--- a/samples/Plugin.Maui.Exif.Sample/MainPage.xaml.cs
+++ b/samples/Plugin.Maui.Exif.Sample/MainPage.xaml.cs
@@ -14,6 +14,13 @@ public partial class MainPage : ContentPage
         this.exif = exif;
     }
 
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        await PermissionUtility.RequestLocationPermissionAsync();
+        await PermissionUtility.RequestMediaLocationPermissionAsync();
+    }
+
     private async void OnSelectImageClicked(object sender, EventArgs e)
     {
         try

--- a/samples/Plugin.Maui.Exif.Sample/Platforms/Android/AndroidManifest.xml
+++ b/samples/Plugin.Maui.Exif.Sample/Platforms/Android/AndroidManifest.xml
@@ -5,6 +5,8 @@
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+	<!-- For accessing media location -->
+	<uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
 	<uses-permission android:name="android.permission.CAMERA" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-feature android:name="android.hardware.camera" android:required="false" />

--- a/samples/Plugin.Maui.Exif.Sample/Platforms/Android/AndroidManifest.xml
+++ b/samples/Plugin.Maui.Exif.Sample/Platforms/Android/AndroidManifest.xml
@@ -7,6 +7,8 @@
 	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 	<!-- For accessing media location -->
 	<uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
+	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 	<uses-permission android:name="android.permission.CAMERA" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-feature android:name="android.hardware.camera" android:required="false" />

--- a/samples/Plugin.Maui.Exif.Sample/Platforms/Android/MainActivity.cs
+++ b/samples/Plugin.Maui.Exif.Sample/Platforms/Android/MainActivity.cs
@@ -11,7 +11,6 @@ namespace Plugin.Maui.Feature.Sample;
 public class MainActivity : MauiAppCompatActivity
 {
     const int RequestMediaLocationId = 1001;
-    const int RequestReadImagesId = 1002;
 
     protected override void OnCreate(Bundle savedInstanceState)
     {

--- a/samples/Plugin.Maui.Exif.Sample/Platforms/Android/MainActivity.cs
+++ b/samples/Plugin.Maui.Exif.Sample/Platforms/Android/MainActivity.cs
@@ -10,33 +10,4 @@ namespace Plugin.Maui.Feature.Sample;
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
-    const int RequestPermissionsId = 1001;
-
-    protected override void OnCreate(Bundle savedInstanceState)
-    {
-        base.OnCreate(savedInstanceState);
-        RequestLocationRelatedPermissions();
-    }
-
-    void RequestLocationRelatedPermissions()
-    {
-        if (OperatingSystem.IsAndroidVersionAtLeast(29)) // Android 10+
-        {
-            var permissionsToRequest = new List<string>();
-
-            if (ContextCompat.CheckSelfPermission(this, Manifest.Permission.AccessFineLocation) != Permission.Granted)
-                permissionsToRequest.Add(Manifest.Permission.AccessFineLocation);
-
-            if (ContextCompat.CheckSelfPermission(this, Manifest.Permission.AccessCoarseLocation) != Permission.Granted)
-                permissionsToRequest.Add(Manifest.Permission.AccessCoarseLocation);
-
-            if (ContextCompat.CheckSelfPermission(this, Manifest.Permission.AccessMediaLocation) != Permission.Granted)
-                permissionsToRequest.Add(Manifest.Permission.AccessMediaLocation);
-
-            if (permissionsToRequest.Count > 0)
-            {
-                ActivityCompat.RequestPermissions(this, permissionsToRequest.ToArray(), RequestPermissionsId);
-            }
-        }
-    }
 }

--- a/samples/Plugin.Maui.Exif.Sample/Platforms/Android/MainActivity.cs
+++ b/samples/Plugin.Maui.Exif.Sample/Platforms/Android/MainActivity.cs
@@ -1,9 +1,6 @@
-﻿using Android;
-using Android.App;
+﻿using Android.App;
 using Android.Content.PM;
 using Android.OS;
-using AndroidX.Core.App;
-using AndroidX.Core.Content;
 
 namespace Plugin.Maui.Feature.Sample;
 

--- a/samples/Plugin.Maui.Exif.Sample/Platforms/Android/MainActivity.cs
+++ b/samples/Plugin.Maui.Exif.Sample/Platforms/Android/MainActivity.cs
@@ -10,23 +10,32 @@ namespace Plugin.Maui.Feature.Sample;
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
-    const int RequestMediaLocationId = 1001;
+    const int RequestPermissionsId = 1001;
 
     protected override void OnCreate(Bundle savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
-
-        RequestMediaLocationPermission();
+        RequestLocationRelatedPermissions();
     }
 
-    void RequestMediaLocationPermission()
+    void RequestLocationRelatedPermissions()
     {
         if (OperatingSystem.IsAndroidVersionAtLeast(29)) // Android 10+
         {
+            var permissionsToRequest = new List<string>();
+
+            if (ContextCompat.CheckSelfPermission(this, Manifest.Permission.AccessFineLocation) != Permission.Granted)
+                permissionsToRequest.Add(Manifest.Permission.AccessFineLocation);
+
+            if (ContextCompat.CheckSelfPermission(this, Manifest.Permission.AccessCoarseLocation) != Permission.Granted)
+                permissionsToRequest.Add(Manifest.Permission.AccessCoarseLocation);
+
             if (ContextCompat.CheckSelfPermission(this, Manifest.Permission.AccessMediaLocation) != Permission.Granted)
+                permissionsToRequest.Add(Manifest.Permission.AccessMediaLocation);
+
+            if (permissionsToRequest.Count > 0)
             {
-                ActivityCompat.RequestPermissions(this, new string[] 
-                { Manifest.Permission.AccessMediaLocation}, RequestMediaLocationId);
+                ActivityCompat.RequestPermissions(this, permissionsToRequest.ToArray(), RequestPermissionsId);
             }
         }
     }

--- a/samples/Plugin.Maui.Exif.Sample/Platforms/Android/MainActivity.cs
+++ b/samples/Plugin.Maui.Exif.Sample/Platforms/Android/MainActivity.cs
@@ -1,10 +1,34 @@
-﻿using Android.App;
+﻿using Android;
+using Android.App;
 using Android.Content.PM;
 using Android.OS;
+using AndroidX.Core.App;
+using AndroidX.Core.Content;
 
 namespace Plugin.Maui.Feature.Sample;
 
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
+    const int RequestMediaLocationId = 1001;
+    const int RequestReadImagesId = 1002;
+
+    protected override void OnCreate(Bundle savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+
+        RequestMediaLocationPermission();
+    }
+
+    void RequestMediaLocationPermission()
+    {
+        if (OperatingSystem.IsAndroidVersionAtLeast(29)) // Android 10+
+        {
+            if (ContextCompat.CheckSelfPermission(this, Manifest.Permission.AccessMediaLocation) != Permission.Granted)
+            {
+                ActivityCompat.RequestPermissions(this, new string[] 
+                { Manifest.Permission.AccessMediaLocation}, RequestMediaLocationId);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adding a note in README about accessing GPS metadata while using  MediaPicker's `PickPhotoAsync()`  and `CapturePhotoAsync` Android. Updated sample app with those changes too.

For  `MediaPicker.CapturePhotoAsync()`, we don't have direct control over the EXIF data it produces. Internally, it uses Android's ACTION_IMAGE_CAPTURE intent, which delegates the photo capture to whatever camera app the user chooses. That camera app decides whether or not to include EXIF GPS data.

If the app has location permissions (ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION), and the selected camera app supports embedding location data, GPS tags may be included in the result. But this behavior is not guaranteed , it depends entirely on the camera app's implementation and whether location tagging is enabled.

In short, granting location permissions can help, but it's not something we can fully rely on or enforce.
 Fixes #2 