### PR TITLE
Fix WriteToStreamAsync not preserving EXIF data on Android

### DIFF
--- a/src/Plugin.Maui.Exif/Exif.android.cs
+++ b/src/Plugin.Maui.Exif/Exif.android.cs
@@ -419,15 +419,43 @@ partial class ExifImplementation : IExif
         {
             try
             {
-                // For streams, we need to copy the input to output and then modify the output
-                inputStream.Position = 0;
-                inputStream.CopyTo(outputStream);
-                outputStream.Position = 0;
+                // AndroidX ExifInterface.SaveAttributes() does not reliably persist changes
+                // when operating directly on streams. The workaround is to write to a
+                // temporary file, apply the EXIF modifications there, then copy the result
+                // to the output stream.
+                var tempFilePath = Path.Combine(Path.GetTempPath(), $"exif_temp_{Guid.NewGuid()}.jpg");
 
-                var exifInterface = new ExifInterface(outputStream);
-                WriteExifData(exifInterface, exifData);
-                exifInterface.SaveAttributes();
-                return true;
+                try
+                {
+                    // Write input stream to temp file
+                    inputStream.Position = 0;
+                    using (var fileStream = File.Create(tempFilePath))
+                    {
+                        inputStream.CopyTo(fileStream);
+                    }
+
+                    // Apply EXIF data using file-based ExifInterface (reliable)
+                    var exifInterface = new ExifInterface(tempFilePath);
+                    WriteExifData(exifInterface, exifData);
+                    exifInterface.SaveAttributes();
+
+                    // Copy the modified file to the output stream
+                    using (var resultStream = File.OpenRead(tempFilePath))
+                    {
+                        resultStream.CopyTo(outputStream);
+                    }
+
+                    outputStream.Position = 0;
+                    return true;
+                }
+                finally
+                {
+                    // Clean up temp file
+                    if (File.Exists(tempFilePath))
+                    {
+                        File.Delete(tempFilePath);
+                    }
+                }
             }
             catch (Exception)
             {


### PR DESCRIPTION
## Description

Fixes #13

The Android `ExifInterface.SaveAttributes()` does not reliably persist EXIF modifications when operating directly on streams. The previous implementation copied the input to the output stream, then tried to modify it in-place via `new ExifInterface( but the changes were silently lost.outputStream)` 

### Root Cause

AndroidX `ExifInterface` is designed primarily for file-based operations. When constructed from a stream, `SaveAttributes()` either doesn't flush correctly or the stream's internal state becomes inconsistent. This is a known limitation of the AndroidX library.

### Fix

Use the same temp-file approach that `WriteToFileAsync` already uses successfully:

1. Write the input stream to a temporary file
2. Create `ExifInterface` from the **file path** (reliable)
3. Set attributes and call `SaveAttributes()`
4. Copy the modified file to the output stream
5. Clean up the temp file

This implements the workaround  callers no longer need to manually write to a file and reload.transparently 

### Testing

Verified structurally against the working `WriteToFileAsync` pattern. The fix applies the exact same code path that already works, just with an intermediate temp file for the stream case.

### Breaking Changes
 same API, correct behavior now.None 
